### PR TITLE
Index code and fix Vercel deployment

### DIFF
--- a/DEPLOYMENT_FIX.md
+++ b/DEPLOYMENT_FIX.md
@@ -8,6 +8,17 @@
 - **Files Updated**: All API routes now use the singleton Prisma client
 
 ### 2. **Enhanced Error Handling**
+### 3. **Align Prisma URL with Vercel env**
+- Problem: Prisma schema expected `POSTGRES_PRISMA_URL` while docs and Vercel use `DATABASE_URL`, causing `prisma generate`/migrate to fail on build.
+- Solution: Updated `prisma/schema.prisma` datasource to `env("DATABASE_URL")` and `lib/prisma.ts` to prefer `DATABASE_URL`.
+
+### 4. **Avoid running migrations during build**
+- Problem: Vercel build ran `prisma migrate deploy`, which requires DB access and often fails in ephemeral build environments.
+- Solution: Changed `package.json` build script to `prisma generate && next build`. Migrations should be run post-deploy via CLI.
+
+### 5. **Neon test script env compatibility**
+- Problem: `scripts/test-neon-connection.js` only read `POSTGRES_PRISMA_URL`.
+- Solution: Updated to read `DATABASE_URL` first with fallbacks.
 - **Problem**: Generic error messages made debugging difficult
 - **Solution**: Added specific error handling for database connection issues and unique constraint violations
 - **Files Updated**: `/app/api/auth/register/route.ts`

--- a/VERCEL_DEPLOYMENT.md
+++ b/VERCEL_DEPLOYMENT.md
@@ -107,10 +107,19 @@ NEXTAUTH_URL = https://your-app-name.vercel.app
    ```
    Or use an online generator: [generate-secret.vercel.app](https://generate-secret.vercel.app/32)
 
+> Note: Migrations should not run during Vercel build. Run them separately via CLI after the first deploy.
+
 ### Step 4: Deploy
 1. Click "Deploy"
 2. Wait for the build to complete
-3. Your app will be available at `https://your-app-name.vercel.app`
+3. After the first successful build, run migrations from your machine:
+
+```bash
+vercel login
+vercel link
+npx prisma migrate deploy
+```
+4. Your app will be available at `https://your-app-name.vercel.app`
 
 ## 🗄️ Database Migration
 
@@ -198,7 +207,7 @@ Error: Module not found
 ```
 **Solution:**
 - Check if all dependencies are in `package.json`
-- Ensure build command is correct
+- Ensure build command is `prisma generate && next build` (migrations run separately)
 - Check for TypeScript errors
 
 #### **Migration Issues**

--- a/app/api/health/route.ts
+++ b/app/api/health/route.ts
@@ -15,7 +15,7 @@ export async function GET() {
       userCount,
       timestamp: new Date().toISOString(),
       environment: process.env.NODE_ENV,
-      databaseUrl: process.env.POSTGRES_PRISMA_URL ? "Neon (POSTGRES_PRISMA_URL)" : "Standard (DATABASE_URL)",
+      databaseUrl: process.env.DATABASE_URL ? "Standard (DATABASE_URL)" : (process.env.POSTGRES_PRISMA_URL ? "Neon (POSTGRES_PRISMA_URL)" : "Not set"),
     })
   } catch (error) {
     console.error("Health check failed:", error)
@@ -27,7 +27,7 @@ export async function GET() {
         error: error instanceof Error ? error.message : "Unknown error",
         timestamp: new Date().toISOString(),
         environment: process.env.NODE_ENV,
-        databaseUrl: process.env.POSTGRES_PRISMA_URL ? "Neon (POSTGRES_PRISMA_URL)" : "Standard (DATABASE_URL)",
+        databaseUrl: process.env.DATABASE_URL ? "Standard (DATABASE_URL)" : (process.env.POSTGRES_PRISMA_URL ? "Neon (POSTGRES_PRISMA_URL)" : "Not set"),
       },
       { status: 500 }
     )

--- a/lib/prisma.ts
+++ b/lib/prisma.ts
@@ -8,7 +8,7 @@ export const prisma = globalForPrisma.prisma ?? new PrismaClient({
   log: process.env.NODE_ENV === 'development' ? ['query', 'error', 'warn'] : ['error'],
   datasources: {
     db: {
-      url: process.env.POSTGRES_PRISMA_URL || process.env.DATABASE_URL,
+      url: process.env.DATABASE_URL || process.env.POSTGRES_PRISMA_URL,
     },
   },
 })

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,9 +1,7 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  experimental: {
-    serverComponentsExternalPackages: ['@prisma/client'],
-  },
+  serverExternalPackages: ['@prisma/client'],
   webpack: (config, { isServer }) => {
     if (isServer) {
       config.externals.push('@prisma/client');

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",
-    "build": "prisma generate && prisma migrate deploy && next build",
+    "build": "prisma generate && next build",
     "start": "next start",
     "lint": "next lint",
     "postinstall": "prisma generate",

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -7,7 +7,7 @@ generator client {
 
 datasource db {
   provider = "postgresql"
-  url      = env("POSTGRES_PRISMA_URL")
+  url      = env("DATABASE_URL")
 }
 
 // User model for authentication and profile management

--- a/scripts/test-neon-connection.js
+++ b/scripts/test-neon-connection.js
@@ -11,16 +11,16 @@ async function testNeonConnection() {
   console.log('🔍 Testing Neon database connection...\n');
   
   // Check environment variables
-  const postgresUrl = process.env.POSTGRES_PRISMA_URL;
+  const postgresUrl = process.env.DATABASE_URL || process.env.POSTGRES_PRISMA_URL || process.env.POSTGRES_URL_NO_SSL;
   const postgresUrlNoSsl = process.env.POSTGRES_URL_NO_SSL;
   
   console.log('Environment Variables:');
-  console.log(`- POSTGRES_PRISMA_URL: ${postgresUrl ? '✅ Set' : '❌ Not set'}`);
+  console.log(`- DATABASE_URL/POSTGRES_PRISMA_URL: ${postgresUrl ? '✅ Set' : '❌ Not set'}`);
   console.log(`- POSTGRES_URL_NO_SSL: ${postgresUrlNoSsl ? '✅ Set' : '❌ Not set'}`);
   console.log(`- NODE_ENV: ${process.env.NODE_ENV || 'undefined'}\n`);
   
   if (!postgresUrl) {
-    console.error('❌ POSTGRES_PRISMA_URL is not set!');
+    console.error('❌ DATABASE_URL is not set!');
     console.log('💡 Make sure you have pulled the latest environment variables from Vercel:');
     console.log('   vercel env pull .env.development.local');
     process.exit(1);


### PR DESCRIPTION
Fix Vercel deployment by aligning Prisma's database URL environment variable and preventing migrations during build.

The Vercel deployment was failing because the Prisma schema expected `POSTGRES_PRISMA_URL` while Vercel typically provides `DATABASE_URL`. Additionally, running `prisma migrate deploy` during the Vercel build step often causes failures as it requires an active database connection, which is better handled post-deployment via the Vercel CLI.

---
<a href="https://cursor.com/background-agent?bcId=bc-a9342331-31f3-4c51-88ae-373f338d164b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a9342331-31f3-4c51-88ae-373f338d164b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

